### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/cupsadarius/gcp_resource_cleaner/security/code-scanning/4](https://github.com/cupsadarius/gcp_resource_cleaner/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient, as there is no indication that write permissions are needed. This change will ensure that the `GITHUB_TOKEN` has only the necessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
